### PR TITLE
Add solver logic and structure codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.egg-info
+**/*.ipynb_checkpoints
+blank_slate_ubi_us/data/**
+**/*.pyc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+format:
+	black . -l 79

--- a/blank_slate_ubi_us/__init__.py
+++ b/blank_slate_ubi_us/__init__.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+REPO = Path(".")

--- a/blank_slate_ubi_us/common/__init__.py
+++ b/blank_slate_ubi_us/common/__init__.py
@@ -1,0 +1,1 @@
+from .helpers import *

--- a/blank_slate_ubi_us/common/helpers.py
+++ b/blank_slate_ubi_us/common/helpers.py
@@ -1,0 +1,110 @@
+from openfisca_us.model_api import *
+from openfisca_us.tools.baseline_variables import baseline_variables
+from openfisca_us.reforms import abolish
+from openfisca_us import Microsimulation
+import logging
+from blank_slate_ubi_us import REPO
+
+logging.basicConfig(level=logging.INFO)
+
+def prepare_simulation():
+    """Adjusts the microsimulation for simulation - turns off reported net income.
+    """
+    class reform(Reform):
+        def apply(self):
+            self.neutralize_variable("spm_unit_net_income_reported")
+
+    return reform
+
+def flat_tax(rate: float) -> Reform:
+    """Create a reform converting federal, 
+
+    Args:
+        rate (float): The flat tax rate.
+
+    Returns:
+        Reform: The OpenFisca reform.
+    """
+    class spm_unit_taxes(baseline_variables["spm_unit_taxes"]):
+        def formula(spm_unit, period, parameters):
+            flat_tax = add(spm_unit, period, ["adjusted_gross_income"]) * rate
+            state_tax = spm_unit("spm_unit_state_tax", period)
+            return flat_tax + state_tax
+
+
+    class reform(Reform):
+        def apply(self):
+            self.update_variable(spm_unit_taxes)
+
+    return reform
+
+def ubi(person_amount: float) -> Reform:
+    """Create a reform adding a universal basic income.
+
+    Args:
+        person_amount (float): The yearly per-person amount.
+
+    Returns:
+        Reform: The OpenFisca reform.
+    """
+    class ubi(Variable):
+        value_type = float
+        entity = Person
+        label = "UBI"
+        definition_period = YEAR
+
+        def formula(person, period, parameters):
+            return person_amount
+    
+    class spm_unit_benefits(baseline_variables["spm_unit_benefits"]):
+        def formula(spm_unit, period, parameters):
+            original_benefits = baseline_variables["spm_unit_benefits"].formula(spm_unit, period, parameters)
+            ubi_amount = add(spm_unit, period, ["ubi"])
+            return original_benefits + ubi_amount
+
+    class reform(Reform):
+        def apply(self):
+            self.add_variable(ubi)
+            self.update_variable(spm_unit_benefits)
+
+    return reform
+
+blank_slate_df_path = REPO / "data" / "blank_slate_df.csv.gz"
+
+blank_slate_funding = (
+    prepare_simulation(),
+    abolish("wic"),
+    abolish("snap_normal_allotment"),
+    abolish("ssi"),
+    flat_tax(0.4),
+)
+
+BLANK_SLATE_FUNDING_SUBREFORM_NAMES = [
+    "Abolish WIC",
+    "Abolish SNAP",
+    "Abolish SSI",
+    "40% flat tax",
+]
+
+if not blank_slate_df_path.exists():
+    logging.info(f"Did not find {blank_slate_df_path}, generating.")
+    blank_slate_df_path.parent.mkdir(exist_ok=True)
+
+    baseline = Microsimulation(prepare_simulation())
+    funded = Microsimulation(blank_slate_funding)
+
+    blank_slate_df = pd.DataFrame(dict(
+        baseline_spm_unit_net_income=baseline.calc("spm_unit_net_income", 2022),
+        count_child=baseline.calc("is_child", map_to="spm_unit", period=2022),
+        count_adult=baseline.calc("is_wa_adult", map_to="spm_unit", period=2022),
+        count_senior=baseline.calc("is_senior", map_to="spm_unit", period=2022),
+        funded_spm_unit_net_income=funded.calc("spm_unit_net_income", 2022),
+        weight=baseline.calc("spm_unit_weight", 2022),
+    ))
+
+    blank_slate_df.to_csv(blank_slate_df_path, compression="gzip")
+    logging.info(f"Completed generation of {blank_slate_df_path}.")
+else:
+    blank_slate_df = pd.read_csv(blank_slate_df_path, compression="gzip")
+
+UBI_FUNDING = ((blank_slate_df.baseline_spm_unit_net_income - blank_slate_df.funded_spm_unit_net_income) * blank_slate_df.weight).sum()

--- a/blank_slate_ubi_us/foundational.py
+++ b/blank_slate_ubi_us/foundational.py
@@ -1,0 +1,46 @@
+from typing import Tuple
+from blank_slate_ubi_us.common import UBI_FUNDING, blank_slate_df
+import numpy as np
+from scipy.optimize import differential_evolution
+
+df = blank_slate_df
+
+def get_senior_amount(
+    child_amount: float,
+    adult_amount: float,
+) -> float:
+    return (
+        UBI_FUNDING
+        - child_amount * (df.count_child * df.weight).sum()
+        - adult_amount * (df.count_adult * df.weight).sum()
+    ) / (df.count_senior * df.weight).sum()
+
+
+def mean_percentage_loss(
+    child_amount: float,
+    adult_amount: float,
+) -> float:
+    senior_amount = get_senior_amount(child_amount, adult_amount)
+    final_net_income = (
+        df.funded_spm_unit_net_income
+        + df.count_child * child_amount
+        + df.count_adult * adult_amount
+        + df.count_senior * senior_amount
+    )
+    loss = np.maximum(0, df.baseline_spm_unit_net_income / final_net_income - 1)
+    return loss.mean()
+
+def solve_foundational_model() -> Tuple[float, float, float]:
+    """Solves for the child, adult and senior UBI amounts with
+    the least mean percentage loss.
+
+    Returns:
+        Tuple[float, float, float]: The optimal child, adult and senior UBI amounts.
+    """
+
+    child_amount, adult_amount = differential_evolution(
+        lambda x: mean_percentage_loss(*x),
+        bounds=[(0, 2e4), (0, 2e4)],
+    ).x
+    senior_amount = get_senior_amount(child_amount, adult_amount)
+    return child_amount, adult_amount, senior_amount

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(
+   name="blank_slate_ubi_us",
+   version="0.0.1",
+   packages=["blank_slate_ubi_us"],
+   install_requires=[
+       "pandas",
+       "numpy",
+       "scipy",
+       "openfisca-us",
+       "plotly",
+       "ubicenter",
+       "black",
+   ]
+)


### PR DESCRIPTION
This PR adds logic to solve the Foundational UBI model (child/adult/senior amounts) using differential evolution, and manages a `blank_slate_df.csv.gz` file which contains a row for each SPM unit in the CPS microdata, with the following columns:

* `baseline_spm_unit_net_income`
* `count_child`
* `count_adult`
* `count_senior`
* `funded_spm_unit_net_income`: the net income after benefit abolitions and the flat tax reform, but before UBI
* `weight`

I've also added some general codebase tools like a Makefile and setup.py.

After this PR, running the `blank_slate_ubi_us/foundational.py` script generates the following output:

```console
(policyengine) nikhil@nikhil-pc:~/ubicenter/blank-slate-ubi-us$ python blank_slate_ubi_us/foundational.py 
Foundational UBI:
  Child: $3,278 per year
  Adult: $9,044 per year
  Senior: $9,307 per year
Mean percentage loss: 4.59%
```